### PR TITLE
Redirect flag that lets users disable redirecting all together

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Set `true` to add the `preload` directive to the `Strict-Transport-Security` hea
 
 If it's `true` and the request contains the headers `X-Forwarded-Proto: https` or `X-Forwarded-Port: 443`, no redirection is returned. This prevent problems with Https load balancer.
 
+#### `redirect(bool $redirect = true)`
+
+Enabled (`true`) or disable (`false`) redirecting all together.
+
 ---
 
 Please see [CHANGELOG](CHANGELOG.md) for more information about recent changes and [CONTRIBUTING](CONTRIBUTING.md) for contributing details.

--- a/src/Https.php
+++ b/src/Https.php
@@ -34,6 +34,11 @@ class Https implements MiddlewareInterface
     private $checkHttpsForward = false;
 
     /**
+     * @var bool Whether to redirect on headers check
+     */
+    private $redirect = true;
+
+    /**
      * Configure the max-age HSTS in seconds.
      */
     public function maxAge(int $maxAge): self
@@ -71,6 +76,16 @@ class Https implements MiddlewareInterface
     public function checkHttpsForward(bool $checkHttpsForward = true): self
     {
         $this->checkHttpsForward = $checkHttpsForward;
+
+        return $this;
+    }
+
+    /**
+     * Enabled or disable redirecting all together.
+     */
+    public function redirect(bool $redirect = true): self
+    {
+        $this->redirect = $redirect;
 
         return $this;
     }
@@ -120,6 +135,10 @@ class Https implements MiddlewareInterface
      */
     private function mustRedirect(ServerRequestInterface $request): bool
     {
+        if ($this->redirect === false) {
+            return false;
+        }
+
         return !$this->checkHttpsForward || (
             $request->getHeaderLine('X-Forwarded-Proto') !== 'https' &&
             $request->getHeaderLine('X-Forwarded-Port') !== '443'

--- a/tests/HttpsTest.php
+++ b/tests/HttpsTest.php
@@ -111,4 +111,33 @@ class HttpsTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('max-age=10', $response->getHeaderLine('Strict-Transport-Security'));
     }
+
+    public function testRedirect()
+    {
+        $request = Factory::createServerRequest([], 'GET', 'http://domain.com');
+
+        $response = Dispatcher::run([
+            new Https(),
+            function () {
+                return Factory::createResponse();
+            },
+        ], $request);
+
+        $this->assertEquals('https://domain.com', $response->getHeaderLine('Location'));
+    }
+
+    public function testNoRedirect()
+    {
+        $request = Factory::createServerRequest([], 'GET', 'http://domain.com');
+
+        $response = Dispatcher::run([
+            (new Https())->redirect(false),
+            function () {
+                return Factory::createResponse();
+            },
+        ], $request);
+
+        $this->assertFalse($response->hasHeader('Location'));
+        $this->assertEquals(200, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
Implemented redirect disabled in such a manner the default/current behavior hasn't changed.

Implement / closes #2 
