### PR TITLE
Fix for incorrect redirect

### DIFF
--- a/src/Https.php
+++ b/src/Https.php
@@ -132,7 +132,7 @@ class Https implements MiddlewareInterface
         if ($response->hasHeader('Location')) {
             $location = parse_url($response->getHeaderLine('Location'));
 
-            if (empty($location['host']) || $location['host'] === $uri->getHost()) {
+            if (!empty($location['host']) && $location['host'] === $uri->getHost()) {
                 $location['scheme'] = 'https';
                 unset($location['port']);
 

--- a/src/Https.php
+++ b/src/Https.php
@@ -133,7 +133,6 @@ class Https implements MiddlewareInterface
             $location = parse_url($response->getHeaderLine('Location'));
 
             if (empty($location['host']) || $location['host'] === $uri->getHost()) {
-                $location['host'] = $uri->getHost();
                 $location['scheme'] = 'https';
                 unset($location['port']);
 

--- a/src/Https.php
+++ b/src/Https.php
@@ -133,6 +133,7 @@ class Https implements MiddlewareInterface
             $location = parse_url($response->getHeaderLine('Location'));
 
             if (empty($location['host']) || $location['host'] === $uri->getHost()) {
+                $location['host'] = $uri->getHost();
                 $location['scheme'] = 'https';
                 unset($location['port']);
 


### PR DESCRIPTION
When manually redirecting an absolute url in your app (By using $response->withHeader('Location', $path)) without host in the address, this middleware would add a https:// prefix to it, causing a redirect that does not point to the same website anymore.

An example of the issue is the following:
If "$response->withHeader('Location', '/login')" is used in the app, or some other middleware that is executed later, this middleware will cause the Location to contain "https:///login" which is not a correct address, breaking the redirect.